### PR TITLE
Add login feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ python manage.py createsuperuser
 python manage.py runserver
 ```
 
+After creating a user, sign in at <http://localhost:8000/accounts/login/>.
+
 ## Apps
 
 - `landing` – homepage.

--- a/honeyshop/settings.py
+++ b/honeyshop/settings.py
@@ -178,3 +178,7 @@ CHANNEL_LAYERS = {
     }
 }
 AUTHENTICATION_BACKENDS = ['django.contrib.auth.backends.ModelBackend','allauth.account.auth_backends.AuthenticationBackend']
+
+# Redirect users to the homepage after login/logout
+LOGIN_REDIRECT_URL = '/'
+LOGOUT_REDIRECT_URL = '/'

--- a/landing/templates/landing/index.html
+++ b/landing/templates/landing/index.html
@@ -18,7 +18,11 @@
         <li class="nav-item"><a class="nav-link" href="/chat/">Chat</a></li>
         <li class="nav-item"><a class="nav-link" href="/memberships/">Membership</a></li>
         <li class="nav-item"><a class="nav-link" href="/loyalty/">Loyalty</a></li>
+        {% if user.is_authenticated %}
+        <li class="nav-item"><a class="nav-link" href="/accounts/logout/">Logout</a></li>
+        {% else %}
         <li class="nav-item"><a class="nav-link" href="/accounts/login/">Login</a></li>
+        {% endif %}
       </ul>
     </div>
   </div>

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}Login - HoneyShop{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h2>{% trans 'Log in' %}</h2>
+  <form method="post" action="{% url 'account_login' %}">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">{% trans 'Log in' %}</button>
+  </form>
+  <p class="mt-3">
+    <a href="{% url 'account_signup' %}">{% trans "Don't have an account? Sign up" %}</a>
+  </p>
+</div>
+{% endblock %}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,14 @@
-from django.test import Client
+import pytest
 from django.urls import reverse
 
 def test_landing_page(client):
     response = client.get(reverse('index'))
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_login_page(client):
+    url = reverse('account_login')
+    response = client.get(url)
+    assert response.status_code == 200
+    assert 'Log in' in response.content.decode()


### PR DESCRIPTION
## Summary
- add login page template
- show login/logout links on landing page
- redirect to home after login
- document login URL in README
- test login page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6842af4f50c0832d948b89c885d87bc0