### PR TITLE
Enhance landing page with hero image

### DIFF
--- a/landing/static/landing/styles.css
+++ b/landing/static/landing/styles.css
@@ -1,0 +1,29 @@
+.hero {
+    position: relative;
+    background-image: url('https://source.unsplash.com/1600x900/?honey');
+    background-size: cover;
+    background-position: center;
+    height: 60vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+}
+.hero::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.4);
+}
+.hero-content {
+    position: relative;
+    z-index: 1;
+    animation: fadeInUp 1s ease-in-out;
+}
+@keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}

--- a/landing/templates/landing/index.html
+++ b/landing/templates/landing/index.html
@@ -1,9 +1,11 @@
+{% load static %}
 <!DOCTYPE html>
 <html>
 <head>
     <title>HoneyShop - Pure Honey</title>
     <meta name="description" content="High-quality pure honey from local beekeepers">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{% static 'landing/styles.css' %}">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
@@ -28,9 +30,13 @@
   </div>
 </nav>
 
-<div class="container py-5 text-center">
-    <h1>HoneyShop</h1>
-    <p class="lead">Chuyên cung cấp mật ong nguyên chất từ những người nuôi ong địa phương.</p>
-</div>
+<header class="hero">
+    <div class="hero-content text-center">
+        <h1 class="display-4">HoneyShop</h1>
+        <p class="lead">Chuyên cung cấp mật ong nguyên chất từ những người nuôi ong địa phương.</p>
+    </div>
+</header>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add hero section with Unsplash background
- animate landing page text with fade-in
- include Bootstrap JS and custom stylesheet

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_6842b8bfa7a4832db4cd2c5590d5dfa1